### PR TITLE
Better failure output for ShouldEqual and ShouldNotEqual

### DIFF
--- a/equality_test.go
+++ b/equality_test.go
@@ -43,7 +43,7 @@ func TestShouldNotEqual(t *testing.T) {
 	fail(t, so(true, ShouldNotEqual, true), "Expected 'true' to NOT equal 'true' (but it did)!")
 
 	pass(t, so("hi", ShouldNotEqual, "bye"))
-	fail(t, so("hi", ShouldNotEqual, "hi"), "Expected 'hi' to NOT equal 'hi' (but it did)!")
+	fail(t, so("hi", ShouldNotEqual, "hi"), "Expected '\"hi\"' to NOT equal '\"hi\"' (but it did)!")
 
 	pass(t, so(&Thing1{"hi"}, ShouldNotEqual, &Thing1{"hi"}))
 	pass(t, so(Thing1{"hi"}, ShouldNotEqual, Thing1{"hi"}))

--- a/equality_test.go
+++ b/equality_test.go
@@ -20,15 +20,15 @@ func TestShouldEqual(t *testing.T) {
 	fail(t, so(true, ShouldEqual, false), "false|true|Expected: 'false' Actual: 'true' (Should be equal)")
 
 	pass(t, so("hi", ShouldEqual, "hi"))
-	fail(t, so("hi", ShouldEqual, "bye"), "bye|hi|Expected: 'bye' Actual: 'hi' (Should be equal)")
+	fail(t, so("hi", ShouldEqual, "bye"), "bye|hi|Expected: '\"bye\"' Actual: '\"hi\"' (Should be equal)")
 
 	pass(t, so(42, ShouldEqual, uint(42)))
 
-	fail(t, so(Thing1{"hi"}, ShouldEqual, Thing1{}), "{}|{hi}|Expected: '{}' Actual: '{hi}' (Should be equal)")
-	fail(t, so(Thing1{"hi"}, ShouldEqual, Thing1{"hi"}), "{hi}|{hi}|Expected: '{hi}' Actual: '{hi}' (Should be equal)")
-	fail(t, so(&Thing1{"hi"}, ShouldEqual, &Thing1{"hi"}), "&{hi}|&{hi}|Expected: '&{hi}' Actual: '&{hi}' (Should be equal)")
+	fail(t, so(Thing1{"hi"}, ShouldEqual, Thing1{}), "{}|{hi}|Expected: 'assertions.Thing1{a:\"\"}' Actual: 'assertions.Thing1{a:\"hi\"}' (Should be equal)")
+	fail(t, so(Thing1{"hi"}, ShouldEqual, Thing1{"hi"}), "{hi}|{hi}|Expected: 'assertions.Thing1{a:\"hi\"}' Actual: 'assertions.Thing1{a:\"hi\"}' (Should be equal)")
+	fail(t, so(&Thing1{"hi"}, ShouldEqual, &Thing1{"hi"}), "&{hi}|&{hi}|Expected: '&assertions.Thing1{a:\"hi\"}' Actual: '&assertions.Thing1{a:\"hi\"}' (Should be equal)")
 
-	fail(t, so(Thing1{}, ShouldEqual, Thing2{}), "{}|{}|Expected: '{}' Actual: '{}' (Should be equal)")
+	fail(t, so(Thing1{}, ShouldEqual, Thing2{}), "{}|{}|Expected: 'assertions.Thing2{a:\"\"}' Actual: 'assertions.Thing1{a:\"\"}' (Should be equal)")
 }
 
 func TestShouldNotEqual(t *testing.T) {

--- a/messages.go
+++ b/messages.go
@@ -2,7 +2,7 @@ package assertions
 
 const ( // equality
 	shouldHaveBeenEqual             = "Expected: '%#v'\nActual:   '%#v'\n(Should be equal)"
-	shouldNotHaveBeenEqual          = "Expected     '%v'\nto NOT equal '%v'\n(but it did)!"
+	shouldNotHaveBeenEqual          = "Expected     '%#v'\nto NOT equal '%#v'\n(but it did)!"
 	shouldHaveBeenAlmostEqual       = "Expected '%v' to almost equal '%v' (but it didn't)!"
 	shouldHaveNotBeenAlmostEqual    = "Expected '%v' to NOT almost equal '%v' (but it did)!"
 	shouldHaveResembled             = "Expected: '%#v'\nActual:   '%#v'\n(Should resemble)!"

--- a/messages.go
+++ b/messages.go
@@ -1,7 +1,7 @@
 package assertions
 
 const ( // equality
-	shouldHaveBeenEqual             = "Expected: '%v'\nActual:   '%v'\n(Should be equal)"
+	shouldHaveBeenEqual             = "Expected: '%#v'\nActual:   '%#v'\n(Should be equal)"
 	shouldNotHaveBeenEqual          = "Expected     '%v'\nto NOT equal '%v'\n(but it did)!"
 	shouldHaveBeenAlmostEqual       = "Expected '%v' to almost equal '%v' (but it didn't)!"
 	shouldHaveNotBeenAlmostEqual    = "Expected '%v' to NOT almost equal '%v' (but it did)!"


### PR DESCRIPTION
When a type implements the [Stringer](https://golang.org/pkg/fmt/#Stringer) interface and the user compares a struct with a string (just a silly mistake), assertions output can be misleading, like:

```
  Expected: 'Hi'
  Actual:   'Hi'
  (Should be equal)
```

This can be verified with this simple code:

``` go
package foo

import (
    "fmt"
    . "github.com/smartystreets/goconvey/convey"
    "testing"
)

type Foo struct {
    x int
}

func (self Foo) String() string {
    return fmt.Sprintf("%d", self.x)
}

func TestFoo(t *testing.T) {

    Convey("Foo", t, func() {
        f := Foo{10}

        // Silly mistake here: should have passed 'f.String()' instead of 'f'
        So(f, ShouldEqual, "10")
    })
}
```

There is a very easy way to fix that: we need to use `%#v` instead of `%v` to print the values of `expected` and `actual`. If we do, the output would be:

```
  Expected: 'foo.Foo{x:10}'
  Actual:   '"10"'
  (Should be equal)
```

What would lead immediately to the error. This pull request fixes that.
