### PR TITLE
Added ShouldHaveErrored and ShouldNotHaveErrored assertions

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -77,6 +77,9 @@ const ( // type checking
 	shouldNotHaveImplemented          = "Expected         '%v'\nto NOT implement '%v'\n(but it did)!"
 	shouldCompareWithInterfacePointer = "The expected value must be a pointer to an interface type (eg. *fmt.Stringer)"
 	shouldNotBeNilActual              = "The actual value was 'nil' and should be a value or a pointer to a value!"
+
+	shouldBeError                   = "Expected error to occur!"
+	shouldBeErrorExpectedMessage    = "Expected error '%v' to occur (but got error: '%v')!"
 )
 
 const ( // time comparisons

--- a/should/should.go
+++ b/should/should.go
@@ -70,4 +70,6 @@ var (
 	HappenWithin         = assertions.ShouldHappenWithin
 	NotHappenWithin      = assertions.ShouldNotHappenWithin
 	BeChronological      = assertions.ShouldBeChronological
+
+	BeError = assertions.ShouldBeError
 )

--- a/type.go
+++ b/type.go
@@ -110,3 +110,43 @@ func ShouldNotImplement(actual interface{}, expectedList ...interface{}) string 
 	}
 	return success
 }
+
+// ShouldBeError receives one parameter and ensures
+// that it is an error interface.
+// It optionally takes an additional second parameter to test
+// an expected error message.
+func ShouldBeError(actual interface{}, expected ...interface{}) string {
+	expectedErrMsg, err := cleanShouldBeErrorInput(actual, expected...)
+
+	if err != "" {
+		return err
+	}
+
+	val, ok := actual.(error)
+	if !ok {
+		return shouldBeError
+	}
+
+	if expectedErrMsg != "" && val.Error() != expectedErrMsg {
+		return fmt.Sprintf(shouldBeErrorExpectedMessage, expectedErrMsg, val.Error())
+	}
+
+	return success
+}
+
+// Clean the `ShouldBeError` assertion input.
+// If a second, optional argument was passed (the expected error message),
+// it will be returned. Otherwise, return an empty string and an error message.
+func cleanShouldBeErrorInput(actual interface{}, expected ...interface{}) (string, string) {
+	if len(expected) == 0 {
+		return "", ""
+	}
+
+	// Make sure the provided is a string
+	val, ok := expected[0].(string)
+	if !ok {
+		return "", "This assertion requires an error message string to be provided (you provided a non-string type)."
+	}
+
+	return val, ""
+}

--- a/type_test.go
+++ b/type_test.go
@@ -2,6 +2,7 @@ package assertions
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
@@ -73,4 +74,20 @@ func TestShouldNotImplement(t *testing.T) {
 	pass(t, so(1, ShouldNotImplement, ioReader))
 	pass(t, so(response, ShouldNotImplement, ioReader))
 	pass(t, so(responsePtr, ShouldNotImplement, ioReader))
+}
+
+func TestShouldBeError(t *testing.T) {
+	funcThatWillError := func(returnError bool) error {
+		if returnError {
+			return errors.New("Fake error.")
+		}
+		return nil
+	}
+
+	pass(t, so(funcThatWillError(true), ShouldBeError))
+	pass(t, so(funcThatWillError(true), ShouldBeError, "Fake error."))
+	fail(t, so(funcThatWillError(false), ShouldBeError), "Expected error to occur!")
+	fail(t, so(1, ShouldBeError), "Expected error to occur!")
+	fail(t, so(funcThatWillError(true), ShouldBeError, 42), "This assertion requires an error message string to be provided (you provided a non-string type).")
+	fail(t, so(funcThatWillError(true), ShouldBeError, "Wrong error"), "Expected error 'Wrong error' to occur (but got error: 'Fake error.')!")
 }


### PR DESCRIPTION
This will add the ability to use two more assertions:

1. `ShouldHaveErrored` - Expect the given `actual` is an error interface.
2. `ShouldNotHaveErrored` - Expect the given `actual` is not an error interface.