### PR TITLE
Test with latest released Go version too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - tip
+  - 1.x
+  - master
 
 install:
   - go get -t ./...


### PR DESCRIPTION
Also, rename `tip` to `master` because that's how Travis CI / gimme calls it now: https://docs.travis-ci.com/user/languages/go#Specifying-a-Go-version-to-use