### PR TITLE
ShouldEqual makes use of Equality method (if defined)

### DIFF
--- a/equal_method.go
+++ b/equal_method.go
@@ -67,8 +67,13 @@ func (this *equalityMethodSpecification) equalMethodReturnsBool() bool {
 }
 
 func (this *equalityMethodSpecification) AreEqual() bool {
-	argument := reflect.ValueOf(this.b)
+	a := reflect.ValueOf(this.a)
+	b := reflect.ValueOf(this.b)
+	return areEqual(a, b) && areEqual(b, a)
+}
+func areEqual(receiver reflect.Value, argument reflect.Value) bool {
+	equalMethod := receiver.MethodByName("Equal")
 	argumentList := []reflect.Value{argument}
-	result := this.equalMethod.Call(argumentList)
+	result := equalMethod.Call(argumentList)
 	return result[0].Bool()
 }

--- a/equal_method.go
+++ b/equal_method.go
@@ -27,10 +27,10 @@ func newEqualityMethodSpecification(a, b interface{}) *equalityMethodSpecificati
 }
 
 func (this *equalityMethodSpecification) IsSatisfied() bool {
-	if !this.sameType() {
+	if !this.bothAreSameType() {
 		return false
 	}
-	if !this.hasEqualMethod() {
+	if !this.typeHasEqualMethod() {
 		return false
 	}
 	if !this.equalMethodReceivesSameTypeForComparison() {
@@ -42,7 +42,7 @@ func (this *equalityMethodSpecification) IsSatisfied() bool {
 	return true
 }
 
-func (this *equalityMethodSpecification) sameType() bool {
+func (this *equalityMethodSpecification) bothAreSameType() bool {
 	this.aType = reflect.TypeOf(this.a)
 	if this.aType.Kind() == reflect.Ptr {
 		this.aType = this.aType.Elem()
@@ -50,7 +50,7 @@ func (this *equalityMethodSpecification) sameType() bool {
 	this.bType = reflect.TypeOf(this.b)
 	return this.aType == this.bType
 }
-func (this *equalityMethodSpecification) hasEqualMethod() bool {
+func (this *equalityMethodSpecification) typeHasEqualMethod() bool {
 	aInstance := reflect.ValueOf(this.a)
 	this.equalMethod = aInstance.MethodByName("Equal")
 	return this.equalMethod != reflect.Value{}

--- a/equal_method.go
+++ b/equal_method.go
@@ -1,0 +1,74 @@
+package assertions
+
+import (
+	"reflect"
+
+	"github.com/smartystreets/logging"
+)
+
+type equalityMethodSpecification struct {
+	a interface{}
+	b interface{}
+
+	aType reflect.Type
+	bType reflect.Type
+
+	equalMethod reflect.Value
+
+	log *logging.Logger
+}
+
+func newEqualityMethodSpecification(a, b interface{}) *equalityMethodSpecification {
+	return &equalityMethodSpecification{
+		a:   a,
+		b:   b,
+		log: logging.Capture(),
+	}
+}
+
+func (this *equalityMethodSpecification) IsSatisfied() bool {
+	if !this.sameType() {
+		return false
+	}
+	if !this.hasEqualMethod() {
+		return false
+	}
+	if !this.equalMethodReceivesSameTypeForComparison() {
+		return false
+	}
+	if !this.equalMethodReturnsBool() {
+		return false
+	}
+	return true
+}
+
+func (this *equalityMethodSpecification) sameType() bool {
+	this.aType = reflect.TypeOf(this.a)
+	if this.aType.Kind() == reflect.Ptr {
+		this.aType = this.aType.Elem()
+	}
+	this.bType = reflect.TypeOf(this.b)
+	return this.aType == this.bType
+}
+func (this *equalityMethodSpecification) hasEqualMethod() bool {
+	aInstance := reflect.ValueOf(this.a)
+	this.equalMethod = aInstance.MethodByName("Equal")
+	return this.equalMethod != reflect.Value{}
+}
+
+func (this *equalityMethodSpecification) equalMethodReceivesSameTypeForComparison() bool {
+	signature := this.equalMethod.Type()
+	return signature.NumIn() == 1 && signature.In(0) == this.aType
+}
+
+func (this *equalityMethodSpecification) equalMethodReturnsBool() bool {
+	signature := this.equalMethod.Type()
+	return signature.NumOut() == 1 && signature.Out(0) == reflect.TypeOf(true)
+}
+
+func (this *equalityMethodSpecification) AreEqual() bool {
+	argument := reflect.ValueOf(this.b)
+	argumentList := []reflect.Value{argument}
+	result := this.equalMethod.Call(argumentList)
+	return result[0].Bool()
+}

--- a/equal_method_test.go
+++ b/equal_method_test.go
@@ -115,11 +115,20 @@ func (this *EqualityFixture) TestIneligible_EqualMethodReturnsWrongOutputs() {
 	this.So(specification.IsSatisfied(), ShouldBeFalse)
 }
 
+func (this *EqualityFixture) TestEligibleAsymmetric_EqualMethodResultDiffersWhenArgumentsInverted() {
+	a := EligibleAsymmetric{a: 0}
+	b := EligibleAsymmetric{a: 1}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeTrue)
+	this.So(specification.AreEqual(), ShouldBeFalse)
+}
+
 /**************************************************************************/
 
 type (
 	Eligible1                            struct{ a string }
 	Eligible2                            struct{ a string }
+	EligibleAsymmetric                   struct{ a int }
 	Ineligible_NoEqualMethod             struct{}
 	Ineligible_EqualMethodNoInputs       struct{}
 	Ineligible_EqualMethodNoOutputs      struct{}
@@ -129,8 +138,11 @@ type (
 	Ineligible_EqualMethodWrongOutput    struct{}
 )
 
-func (this Eligible1) Equal(that Eligible1) bool                                           { return this.a == that.a }
-func (this Eligible2) Equal(that Eligible2) bool                                           { return this.a == that.a }
+func (this Eligible1) Equal(that Eligible1) bool { return this.a == that.a }
+func (this Eligible2) Equal(that Eligible2) bool { return this.a == that.a }
+func (this EligibleAsymmetric) Equal(that EligibleAsymmetric) bool {
+	return this.a == 0
+}
 func (this Ineligible_EqualMethodNoInputs) Equal() bool                                    { return true }
 func (this Ineligible_EqualMethodNoOutputs) Equal(that Ineligible_EqualMethodNoOutputs)    {}
 func (this Ineligible_EqualMethodTooManyInputs) Equal(a, b bool) bool                      { return true }

--- a/equal_method_test.go
+++ b/equal_method_test.go
@@ -1,0 +1,139 @@
+package assertions
+
+import (
+	"testing"
+
+	"github.com/smartystreets/gunit"
+)
+
+func TestEqualityFixture(t *testing.T) {
+	gunit.Run(new(EqualityFixture), t)
+}
+
+type EqualityFixture struct {
+	*gunit.Fixture
+}
+
+func (this *EqualityFixture) TestEligible1() {
+	a := Eligible1{"hi"}
+	b := Eligible1{"hi"}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeTrue)
+	this.So(specification.AreEqual(), ShouldBeTrue)
+}
+
+func (this *EqualityFixture) TestAreEqual() {
+	a := Eligible1{"hi"}
+	b := Eligible1{"hi"}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeTrue)
+	this.So(specification.AreEqual(), ShouldBeTrue)
+}
+
+func (this *EqualityFixture) TestAreNotEqual() {
+	a := Eligible1{"hi"}
+	b := Eligible1{"bye"}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeTrue)
+	this.So(specification.AreEqual(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestEligible2() {
+	a := Eligible2{"hi"}
+	b := Eligible2{"hi"}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeTrue)
+}
+
+func (this *EqualityFixture) TestEligible1_PointerReceiver() {
+	a := &Eligible1{"hi"}
+	b := Eligible1{"hi"}
+	this.So(a.Equal(b), ShouldBeTrue)
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeTrue)
+	this.Println(specification.log.Log)
+}
+
+func (this *EqualityFixture) TestIneligible_PrimitiveTypes() {
+	specification := newEqualityMethodSpecification(1, 1)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_DisparateTypes() {
+	a := Eligible1{"hi"}
+	b := Eligible2{"hi"}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_NoEqualMethod() {
+	a := Ineligible_NoEqualMethod{}
+	b := Ineligible_NoEqualMethod{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_EqualMethodReceivesNoInput() {
+	a := Ineligible_EqualMethodNoInputs{}
+	b := Ineligible_EqualMethodNoInputs{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_EqualMethodReceivesTooManyInputs() {
+	a := Ineligible_EqualMethodTooManyInputs{}
+	b := Ineligible_EqualMethodTooManyInputs{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_EqualMethodReceivesWrongInput() {
+	a := Ineligible_EqualMethodWrongInput{}
+	b := Ineligible_EqualMethodWrongInput{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_EqualMethodReturnsNoOutputs() {
+	a := Ineligible_EqualMethodNoOutputs{}
+	b := Ineligible_EqualMethodNoOutputs{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_EqualMethodReturnsTooManyOutputs() {
+	a := Ineligible_EqualMethodTooManyOutputs{}
+	b := Ineligible_EqualMethodTooManyOutputs{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+func (this *EqualityFixture) TestIneligible_EqualMethodReturnsWrongOutputs() {
+	a := Ineligible_EqualMethodWrongOutput{}
+	b := Ineligible_EqualMethodWrongOutput{}
+	specification := newEqualityMethodSpecification(a, b)
+	this.So(specification.IsSatisfied(), ShouldBeFalse)
+}
+
+/**************************************************************************/
+
+type (
+	Eligible1                            struct{ a string }
+	Eligible2                            struct{ a string }
+	Ineligible_NoEqualMethod             struct{}
+	Ineligible_EqualMethodNoInputs       struct{}
+	Ineligible_EqualMethodNoOutputs      struct{}
+	Ineligible_EqualMethodTooManyInputs  struct{}
+	Ineligible_EqualMethodTooManyOutputs struct{}
+	Ineligible_EqualMethodWrongInput     struct{}
+	Ineligible_EqualMethodWrongOutput    struct{}
+)
+
+func (this Eligible1) Equal(that Eligible1) bool                                           { return this.a == that.a }
+func (this Eligible2) Equal(that Eligible2) bool                                           { return this.a == that.a }
+func (this Ineligible_EqualMethodNoInputs) Equal() bool                                    { return true }
+func (this Ineligible_EqualMethodNoOutputs) Equal(that Ineligible_EqualMethodNoOutputs)    {}
+func (this Ineligible_EqualMethodTooManyInputs) Equal(a, b bool) bool                      { return true }
+func (this Ineligible_EqualMethodTooManyOutputs) Equal(bool) (bool, bool)                  { return true, true }
+func (this Ineligible_EqualMethodWrongInput) Equal(a string) bool                          { return true }
+func (this Ineligible_EqualMethodWrongOutput) Equal(Ineligible_EqualMethodWrongOutput) int { return 0 }

--- a/equality.go
+++ b/equality.go
@@ -22,7 +22,6 @@ func shouldEqual(actual, expected interface{}) (message string) {
 	defer func() {
 		if r := recover(); r != nil {
 			message = serializer.serialize(expected, actual, fmt.Sprintf(shouldHaveBeenEqual, expected, actual))
-			return
 		}
 	}()
 
@@ -33,7 +32,8 @@ func shouldEqual(actual, expected interface{}) (message string) {
 			message = fmt.Sprintf(shouldHaveBeenEqual, expected, actual)
 			return serializer.serialize(expected, actual, message)
 		}
-	} else if matchError := oglematchers.Equals(expected).Matches(actual); matchError != nil {
+	}
+	if matchError := oglematchers.Equals(expected).Matches(actual); matchError != nil {
 		expectedSyntax := fmt.Sprintf("%v", expected)
 		actualSyntax := fmt.Sprintf("%v", actual)
 		if expectedSyntax == actualSyntax && reflect.TypeOf(expected) != reflect.TypeOf(actual) {

--- a/equality.go
+++ b/equality.go
@@ -26,7 +26,14 @@ func shouldEqual(actual, expected interface{}) (message string) {
 		}
 	}()
 
-	if matchError := oglematchers.Equals(expected).Matches(actual); matchError != nil {
+	if specification := newEqualityMethodSpecification(expected, actual); specification.IsSatisfied() {
+		if specification.AreEqual() {
+			return success
+		} else {
+			message = fmt.Sprintf(shouldHaveBeenEqual, expected, actual)
+			return serializer.serialize(expected, actual, message)
+		}
+	} else if matchError := oglematchers.Equals(expected).Matches(actual); matchError != nil {
 		expectedSyntax := fmt.Sprintf("%v", expected)
 		actualSyntax := fmt.Sprintf("%v", actual)
 		if expectedSyntax == actualSyntax && reflect.TypeOf(expected) != reflect.TypeOf(actual) {
@@ -34,8 +41,7 @@ func shouldEqual(actual, expected interface{}) (message string) {
 		} else {
 			message = fmt.Sprintf(shouldHaveBeenEqual, expected, actual)
 		}
-		message = serializer.serialize(expected, actual, message)
-		return
+		return serializer.serialize(expected, actual, message)
 	}
 
 	return success

--- a/equality.go
+++ b/equality.go
@@ -11,7 +11,11 @@ import (
 	"github.com/smartystreets/assertions/internal/oglematchers"
 )
 
-// ShouldEqual receives exactly two parameters and does an equality check.
+// ShouldEqual receives exactly two parameters and does an equality check
+// using the following semantics:
+// 1. If the expected and actual values implement an Equal method in the form
+// `func (this T) Equal(that T) bool` then call the method. If true, they are equal.
+// 2. The expected and actual values are judged equal or not by oglematchers.Equals.
 func ShouldEqual(actual interface{}, expected ...interface{}) string {
 	if message := need(1, expected); message != success {
 		return message
@@ -48,6 +52,7 @@ func shouldEqual(actual, expected interface{}) (message string) {
 }
 
 // ShouldNotEqual receives exactly two parameters and does an inequality check.
+// See ShouldEqual for details on how equality is determined.
 func ShouldNotEqual(actual interface{}, expected ...interface{}) string {
 	if fail := need(1, expected); fail != success {
 		return fail

--- a/equality_test.go
+++ b/equality_test.go
@@ -27,6 +27,10 @@ func (this *AssertionsFixture) TestShouldEqual() {
 	this.fail(so(&Thing1{"hi"}, ShouldEqual, &Thing1{"hi"}), "&{hi}|&{hi}|Expected: '&{hi}' Actual: '&{hi}' (Should be equal)")
 
 	this.fail(so(Thing1{}, ShouldEqual, Thing2{}), "{}|{}|Expected: '{}' Actual: '{}' (Should be equal)")
+
+	this.pass(so(ThingWithEqualMethod{"hi"}, ShouldEqual, ThingWithEqualMethod{"hi"}))
+	this.fail(so(ThingWithEqualMethod{"hi"}, ShouldEqual, ThingWithEqualMethod{"bye"}),
+		"{bye}|{hi}|Expected: '{bye}' Actual: '{hi}' (Should be equal)")
 }
 
 func (this *AssertionsFixture) TestShouldNotEqual() {

--- a/equality_test.go
+++ b/equality_test.go
@@ -3,6 +3,7 @@ package assertions
 import (
 	"fmt"
 	"reflect"
+	"time"
 )
 
 func (this *AssertionsFixture) TestShouldEqual() {
@@ -31,6 +32,21 @@ func (this *AssertionsFixture) TestShouldEqual() {
 	this.pass(so(ThingWithEqualMethod{"hi"}, ShouldEqual, ThingWithEqualMethod{"hi"}))
 	this.fail(so(ThingWithEqualMethod{"hi"}, ShouldEqual, ThingWithEqualMethod{"bye"}),
 		"{bye}|{hi}|Expected: '{bye}' Actual: '{hi}' (Should be equal)")
+
+}
+func (this *AssertionsFixture) TestTimeEqual() {
+	var (
+		gopherCon, _ = time.LoadLocation("America/Denver")
+		elsewhere, _ = time.LoadLocation("America/New_York")
+
+		timeNow          = time.Now().In(gopherCon)
+		timeNowElsewhere = timeNow.In(elsewhere)
+		timeLater        = timeNow.Add(time.Nanosecond)
+	)
+
+	this.pass(so(timeNow, ShouldNotResemble, timeNowElsewhere)) // Differing *Location field prevents ShouldResemble!
+	this.pass(so(timeNow, ShouldEqual, timeNowElsewhere))       // Time.Equal method used to determine exact instant.
+	this.pass(so(timeNow, ShouldNotEqual, timeLater))
 }
 
 func (this *AssertionsFixture) TestShouldNotEqual() {

--- a/type.go
+++ b/type.go
@@ -14,9 +14,10 @@ func ShouldHaveSameTypeAs(actual interface{}, expected ...interface{}) string {
 	first := reflect.TypeOf(actual)
 	second := reflect.TypeOf(expected[0])
 
-	if equal := ShouldEqual(first, second); equal != success {
+	if first != second {
 		return serializer.serialize(second, first, fmt.Sprintf(shouldHaveBeenA, actual, second, first))
 	}
+
 	return success
 }
 
@@ -29,7 +30,7 @@ func ShouldNotHaveSameTypeAs(actual interface{}, expected ...interface{}) string
 	first := reflect.TypeOf(actual)
 	second := reflect.TypeOf(expected[0])
 
-	if equal := ShouldEqual(first, second); equal == success {
+	if (actual == nil && expected[0] == nil) || first == second {
 		return fmt.Sprintf(shouldNotHaveBeenA, actual, second)
 	}
 	return success

--- a/utilities_for_test.go
+++ b/utilities_for_test.go
@@ -76,3 +76,11 @@ type StringSliceAlias []string
 type StringStringMapAlias map[string]string
 
 /**************************************************************************/
+
+type ThingWithEqualMethod struct {
+	a string
+}
+
+func (this ThingWithEqualMethod) Equal(that ThingWithEqualMethod) bool {
+	return this.a == that.a
+}


### PR DESCRIPTION
This pull request allows time values to be compared using `ShouldEqual`. More generally, it allows any two structs (or pointers) to be compared if they are of the same time underlying type and that type implements a method named `Equal` that receives another instance of its own type as an input argument and returns a `bool` indicating whether to receiver and the argument are considered equal.

time.Time satisfies the requirements above with it's [`Equal` method](https://golang.org/pkg/time/#Time.Equal):

`func (t Time) Equal(u Time) bool`

---

See the following issues for context leading up to this pull request:

- https://github.com/smartystreets/assertions/issues/20 ("ShouldEqual could be made to work with structs that define an equality method (like time.Time)")
- https://github.com/smartystreets/goconvey/issues/194 ("time.Time and ShouldEqual not kissing in a tree")
