### PR TITLE
Warn user when there's a subtle type diff in ShouldResemble

### DIFF
--- a/equality.go
+++ b/equality.go
@@ -187,6 +187,15 @@ func ShouldResemble(actual interface{}, expected ...interface{}) string {
 
 	if matchError := oglematchers.DeepEquals(expected[0]).Matches(actual); matchError != nil {
 		renderedExpected, renderedActual := render.Render(expected[0]), render.Render(actual)
+		if renderedActual == renderedExpected {
+			// Render doesn't show the types of fields, so something like int(5) will appear
+			// the same as int64(5), but they will cause DeepEquals to return false. This
+			// message at least makes it clear why there appears to be no diff. A better solution
+			// would be to have the diff look for where the two items actually differ, e.g. through
+			// something like https://github.com/go-test/deep
+			message := fmt.Sprintf(shouldHaveResembledButTypeDiff, renderedExpected, renderedActual)
+			return serializer.serializeDetailed(expected[0], actual, message)
+		}
 		message := fmt.Sprintf(shouldHaveResembled, renderedExpected, renderedActual) +
 			composePrettyDiff(renderedExpected, renderedActual)
 		return serializer.serializeDetailed(expected[0], actual, message)

--- a/equality_test.go
+++ b/equality_test.go
@@ -155,6 +155,11 @@ func (this *AssertionsFixture) TestShouldResemble() {
 	// some types come out looking the same when represented with "%#v" so we show type mismatch info:
 	this.fail(so(StringAlias("hi"), ShouldResemble, "hi"), `hi|hi|Expected: '"hi"' Actual: 'assertions.StringAlias("hi")' (Should resemble)!`)
 	this.fail(so(IntAlias(42), ShouldResemble, 42), `42|42|Expected: '42' Actual: 'assertions.IntAlias(42)' (Should resemble)!`)
+
+	type anyVal struct {
+		val interface{}
+	}
+	this.fail(so(anyVal{123}, ShouldResemble, anyVal{int64(123)}), "{123}|{123}|Expected: 'assertions.anyVal{val:123}' Actual: 'assertions.anyVal{val:123}' (Should resemble, but there is a type difference within the two)!")
 }
 
 func (this *AssertionsFixture) TestShouldNotResemble() {

--- a/messages.go
+++ b/messages.go
@@ -9,8 +9,9 @@ const (
 	shouldHaveBeenAlmostEqual    = "Expected '%v' to almost equal '%v' (but it didn't)!"
 	shouldHaveNotBeenAlmostEqual = "Expected '%v' to NOT almost equal '%v' (but it did)!"
 
-	shouldHaveResembled    = "Expected: '%s'\nActual:   '%s'\n(Should resemble)!"
-	shouldNotHaveResembled = "Expected        '%#v'\nto NOT resemble '%#v'\n(but it did)!"
+	shouldHaveResembled            = "Expected: '%s'\nActual:   '%s'\n(Should resemble)!"
+	shouldHaveResembledButTypeDiff = "Expected: '%s'\nActual:   '%s'\n(Should resemble, but there is a type difference within the two)!"
+	shouldNotHaveResembled         = "Expected        '%#v'\nto NOT resemble '%#v'\n(but it did)!"
 
 	shouldBePointers            = "Both arguments should be pointers "
 	shouldHaveBeenNonNilPointer = shouldBePointers + "(the %s was %s)!"


### PR DESCRIPTION
Currently ShouldResemble fails confusingly when the visual diff of two items is the same despite DeepEquals being false.

See more context in comments in the PR, or at these issues https://github.com/smartystreets/assertions/issues/50 https://github.com/smartystreets/goconvey/issues/665